### PR TITLE
Added instruction how to avoid error if node version greated then or …

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ koa-passport version  | koa version | branch
 
 ## Other Examples
 
+## Note
+
+* If your node version greater than or equal 8.4.0 then replace "start": "node --harmony-async-await server.js" with "start": "node server.js"
+
 ### Integrating with databases
 
 * [Example with mongoose module for MongoDB](https://github.com/mapmeld/koa-passport-example)


### PR DESCRIPTION
To avoid this error

node: bad option: --harmony-async-await
npm ERR! code ELIFECYCLE
npm ERR! errno 9
npm ERR! koa-passport-example@3.0.0 start: `node --harmony-async-await server.js`
npm ERR! Exit status 9
npm ERR!
npm ERR! Failed at the koa-passport-example@3.0.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

I have added a note.
